### PR TITLE
[#1]Feat: 로그인/회원가입 Service로직에 인증 로직 추가, Controller 수정

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/auth/controller/AuthController.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/controller/AuthController.java
@@ -2,12 +2,17 @@ package com.twohundredone.taskonserver.auth.controller;
 
 import com.twohundredone.taskonserver.auth.dto.LoginRequest;
 import com.twohundredone.taskonserver.auth.dto.SignUpRequest;
-import com.twohundredone.taskonserver.auth.dto.TokenResponse;
+import com.twohundredone.taskonserver.auth.dto.TokenPair;
+import com.twohundredone.taskonserver.auth.dto.LoginResponse;
 import com.twohundredone.taskonserver.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,9 +31,57 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    // AccessToken → Body
+    // RefreshToken → HttpOnly Cookie
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody @Valid LoginRequest request) {
-        TokenResponse tokens = authService.login(request);
-        return ResponseEntity.ok(tokens);
+    public ResponseEntity<LoginResponse> login(
+            @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        TokenPair tokens = authService.login(request);
+
+        // RefreshToken을 HttpOnly 쿠키에 저장
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(60 * 60 * 24 * 14) // 14일
+                .build();
+
+        response.addHeader("Set-Cookie", refreshCookie.toString());
+
+        // AccessToken만 반환
+        return ResponseEntity.ok(new LoginResponse(tokens.accessToken()));
+    }
+
+
+    // AccessToken 재발급
+    @PostMapping("/reissue")
+    public ResponseEntity<LoginResponse> reissue(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        TokenPair tokens = authService.reissue(request, response);
+        return ResponseEntity.ok(new LoginResponse(tokens.accessToken()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal Long userId, HttpServletResponse response) {
+
+        authService.logout(userId);
+
+        // RefreshToken 쿠키 삭제
+        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        response.addHeader("Set-Cookie", deleteCookie.toString());
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/twohundredone/taskonserver/auth/dto/LoginResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/dto/LoginResponse.java
@@ -1,0 +1,5 @@
+package com.twohundredone.taskonserver.auth.dto;
+
+public record LoginResponse(
+        String accessToken
+) { }

--- a/src/main/java/com/twohundredone/taskonserver/auth/dto/TokenPair.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/dto/TokenPair.java
@@ -1,8 +1,7 @@
 package com.twohundredone.taskonserver.auth.dto;
 
-public record TokenResponse(
+public record TokenPair(
         String accessToken,
         String refreshToken
 ) {
-
 }

--- a/src/main/java/com/twohundredone/taskonserver/auth/service/AuthService.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/service/AuthService.java
@@ -2,12 +2,15 @@ package com.twohundredone.taskonserver.auth.service;
 
 import com.twohundredone.taskonserver.auth.dto.LoginRequest;
 import com.twohundredone.taskonserver.auth.dto.SignUpRequest;
-import com.twohundredone.taskonserver.auth.dto.TokenResponse;
+import com.twohundredone.taskonserver.auth.dto.TokenPair;
 import com.twohundredone.taskonserver.auth.jwt.JwtProvider;
 import com.twohundredone.taskonserver.user.entity.User;
 import com.twohundredone.taskonserver.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -30,6 +33,10 @@ public class AuthService {
             throw new IllegalArgumentException("DUPLICATE_EMAIL");
         }
 
+        if (!request.password().equals(request.passwordCheck())){
+            throw new IllegalArgumentException("PASSWORD_INCORRECT_MISMATCH");
+        }
+
         User user = User.builder()
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
@@ -39,11 +46,21 @@ public class AuthService {
         userRepository.save(user);
     }
 
-    public TokenResponse login(LoginRequest request) {
+    public TokenPair login(LoginRequest request) {
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 request.email(),
                 request.password()
         );
+
+        // TODO: 로그인 된 사용자인지 boolean값 response해주도록 코드 수정
+
+        User user = userRepository.findByEmail(request.email()).orElseThrow(
+                () -> new IllegalArgumentException("USER_NOT_FOUND")
+        );
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new IllegalArgumentException("PASSWORD_INCORRECT");
+        }
 
         Authentication authenticated = authenticationManager.authenticate(authentication);
         CustomUserDetails principal = (CustomUserDetails) authenticated.getPrincipal();
@@ -54,36 +71,61 @@ public class AuthService {
         // Redis에 RefreshToken 저장
         refreshTokenService.save(principal.getId(), refreshToken, jwtProvider.getRefreshTokenValidityMs());
 
-        return new TokenResponse(accessToken, refreshToken);
+        return new TokenPair(accessToken, refreshToken);
     }
 
-    // RefreshToken으로 AccessToken 재발급 (필요시 Refresh도 재발급)
-    public TokenResponse reissue(String refreshToken) {
-        // 1. 토큰 파싱 & 유효성 검증
+    public TokenPair reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        // 쿠키에서 RefreshToken 가져오기
+        String refreshToken = extractRefreshToken(request);
+        if (refreshToken == null)
+            throw new IllegalArgumentException("NO_REFRESH_TOKEN_IN_COOKIE");
+
+        // 토큰 파싱 (유효성 + 만료 여부 확인)
         var claims = jwtProvider.parseToken(refreshToken).getBody();
         Long userId = Long.valueOf(claims.getSubject());
         String email = claims.get("email", String.class);
 
-        // 2. Redis에서 저장된 RefreshToken 확인
-        String stored = refreshTokenService.get(userId);
-        if (stored == null || !stored.equals(refreshToken)) {
+        // Redis 저장 RefreshToken과 비교
+        String saved = refreshTokenService.get(userId);
+        if (saved == null || !saved.equals(refreshToken)) {
             throw new IllegalArgumentException("INVALID_REFRESH_TOKEN");
         }
 
-        // 3. 유저 정보 확인 (탈퇴/정지 등 체크용)
+        // 유저 검증
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("USER_NOT_FOUND"));
 
-        // 4. 새 AccessToken 발급
+        // AccessToken 재발급
         String newAccessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
 
-        // TODO: RefreshToken재발급 시 아래 주석제거
-//        String newRefreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
-//        refreshTokenService.save(user.getUserId(), newRefreshToken, jwtProvider.getRefreshTokenValidityMs());
-//        return new TokenResponse(newAccessToken, newRefreshToken);
+        // RefreshToken Rotation(재발급) — 기업형 보안
+        String newRefreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
+        refreshTokenService.save(user.getUserId(), newRefreshToken, jwtProvider.getRefreshTokenValidityMs());
 
-        // 우선 RefreshToken 재사용: 기존거 내려줌
-        return new TokenResponse(newAccessToken, refreshToken);
+        // 새 RefreshToken을 쿠키에 저장
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", newRefreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .path("/")
+                .maxAge(jwtProvider.getRefreshTokenValidityMs() / 1000)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+
+        return new TokenPair(newAccessToken, newRefreshToken);
+    }
+
+    private String extractRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() == null)
+            return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("refreshToken")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 
     // 로그아웃(RefreshToken 제거)


### PR DESCRIPTION
# issue
#1 

# 변경점
- AuthController에 logout추가
- 기존 TokenResponse를 TokenPair와 LoginResponse로 dto분리
- AuthService에 인증 로직 추가
  - 회원가입 로직에 비밀번호 체크 로직 추가
  - 로그인 로직에 DB에 존재하는 User인지 확인하는 로직과 password확인 로직 추가