### PR TITLE
[#28]Fix: 도메인 + SSL 진행 후 cors설정과 Cookie secure true로 재설정

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/auth/util/CookieUtil.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/util/CookieUtil.java
@@ -12,7 +12,7 @@ public class CookieUtil {
     public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
                 .httpOnly(true)
-                .secure(false)
+                .secure(true)
                 .sameSite("None")
                 .path("/")
                 .maxAge(60 * 60 * 24 * 14) // 14일

--- a/src/main/java/com/twohundredone/taskonserver/config/SecurityConfig.java
+++ b/src/main/java/com/twohundredone/taskonserver/config/SecurityConfig.java
@@ -107,7 +107,12 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         // TODO: 실제 배포 시에는 프론트 도메인만 허용하도록 변경해야 함
-        config.setAllowedOrigins(List.of("http://localhost:8080","http://localhost:3000", "http://localhost:5173"));
+        config.setAllowedOriginPatterns(List.of(
+                "https://taskon.co.kr",
+                "https://www.taskon.co.kr",
+                "http://localhost:*"
+        ));
+
         config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
# issue
#28 

# 변경점
- 서버에 도메인 + SSL 설정
- cors에 도메인 추가
- Cookie에 secure을 true로 다시 변경