### PR TITLE
[#28]Fix: cookie 로컬과 배포환경 분리

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/auth/controller/AuthController.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/controller/AuthController.java
@@ -62,9 +62,10 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<LoginResponse>> login(
             @RequestBody LoginRequest request,
+            HttpServletRequest httpRequest,
             HttpServletResponse response
     ) {
-        LoginResponse loginResponse = authService.login(request, response);
+        LoginResponse loginResponse = authService.login(request, httpRequest, response);
 
         return ResponseEntity.ok(
                 ApiResponse.success(ResponseStatusSuccess.LOGIN_SUCCESS, loginResponse)

--- a/src/main/java/com/twohundredone/taskonserver/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/oauth2/OAuth2SuccessHandler.java
@@ -32,7 +32,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtProvider.createAccessToken(user.getUserId(), user.getEmail());
         String refreshToken = jwtProvider.createRefreshToken(user.getUserId(), user.getEmail());
 
-        CookieUtil.addRefreshTokenCookie(response, refreshToken);
+        CookieUtil.addRefreshTokenCookie(request, response, refreshToken);
 
         onlineStatusService.setOnline(user.getUserId());
 

--- a/src/main/java/com/twohundredone/taskonserver/auth/util/CookieUtil.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/util/CookieUtil.java
@@ -9,16 +9,34 @@ public class CookieUtil {
     public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
 
     // RefreshToken 쿠키 저장
-    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE, refreshToken)
+    public static void addRefreshTokenCookie(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String refreshToken
+    ) {
+        boolean isLocal = request.getServerName().contains("localhost");
+
+        ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
+                .from(REFRESH_TOKEN_COOKIE, refreshToken)
                 .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
                 .path("/")
-                .domain(".taskon.co.kr")
-                .maxAge(60 * 60 * 24 * 14) // 14일
-                .build();
-        response.addHeader("Set-Cookie", cookie.toString());
+                .maxAge(60 * 60 * 24 * 14);
+
+        if (isLocal) {
+            // 🔥 로컬테스트용
+            cookieBuilder
+                    .secure(false)
+                    .sameSite("Lax") // localhost에서는 None 불가
+                    .domain(null);
+        } else {
+            // 🔥 실제 배포(api.taskon.co.kr)
+            cookieBuilder
+                    .secure(true)
+                    .sameSite("None")
+                    .domain(".taskon.co.kr"); // 모든 서브도메인 허용
+        }
+
+        response.addHeader("Set-Cookie", cookieBuilder.build().toString());
     }
 
     // RefreshToken 쿠키 읽기

--- a/src/main/java/com/twohundredone/taskonserver/config/SwaggerConfig.java
+++ b/src/main/java/com/twohundredone/taskonserver/config/SwaggerConfig.java
@@ -31,14 +31,14 @@ import org.springframework.context.annotation.Configuration;
 )
 public class SwaggerConfig {
 
-        // Swagger 서버 주소 자동 감지 설정
         @Bean
         public OpenAPI customOpenAPI() {
                 return new OpenAPI()
-                        .addServersItem(new Server().url("https://api.taskon.co.kr"))
+                        .addServersItem(new Server().url("/"))
                         .info(new Info()
                                 .title("TaskOn API 명세서")
                                 .version("v1")
                                 .description("TaskOn 프로젝트 API 문서입니다."));
         }
 }
+


### PR DESCRIPTION
# issue
#28 

# 변경점
- Refresh Token의 cookie를 로컬과 배포 환경 분리