### PR TITLE
[38]Fix: Swagger에서 사용자 정보 변경 api에 발생하는 500에러와 name이 필수값으로 되어있는 부분을 수정

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/oauth2/OAuth2SuccessHandler.java
@@ -36,7 +36,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         onlineStatusService.setOnline(user.getUserId());
 
-        String redirectUrl = "https://taskon.co.kr/oauth2/success?accessToken=" + accessToken;
+        String redirectUrl = "http://localhost:3000/oauth2/success?accessToken=" + accessToken;
 
         try {
             response.sendRedirect(redirectUrl);

--- a/src/main/java/com/twohundredone/taskonserver/user/controller/UserController.java
+++ b/src/main/java/com/twohundredone/taskonserver/user/controller/UserController.java
@@ -21,6 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,8 +43,8 @@ public class UserController {
     @PatchMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<UserProfileResponse>> updateProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            @Valid @RequestPart(value = "request") UserProfileUpdateRequest request
+            @Valid @ModelAttribute UserProfileUpdateRequest request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
         UserProfileResponse response = userService.updateProfile(userDetails.getId(), request, profileImage);
         return ResponseEntity.ok(

--- a/src/main/java/com/twohundredone/taskonserver/user/dto/UserProfileUpdateRequest.java
+++ b/src/main/java/com/twohundredone/taskonserver/user/dto/UserProfileUpdateRequest.java
@@ -1,13 +1,23 @@
 package com.twohundredone.taskonserver.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record UserProfileUpdateRequest(
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileUpdateRequest {
+        @Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         @Pattern(
                 regexp = "^[가-힣a-zA-Z]{2,15}$",
                 message = "이름은 한글 또는 영어로만 구성된 2~15자 이름이어야 합니다."
         )
-        String name
-) {
+        private String name;
 
+        public void setName(String name) {
+                this.name = name;
+        }
 }

--- a/src/main/java/com/twohundredone/taskonserver/user/service/UserService.java
+++ b/src/main/java/com/twohundredone/taskonserver/user/service/UserService.java
@@ -13,6 +13,7 @@ import com.twohundredone.taskonserver.user.dto.UserProfileUpdateRequest;
 import com.twohundredone.taskonserver.user.entity.User;
 import com.twohundredone.taskonserver.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
@@ -31,7 +33,12 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        user.updateName(request.name());
+        log.info(">>> request.name = {}", request.getName());
+
+
+        if (request.getName() != null && !request.getName().isBlank()) {
+            user.updateName(request.getName());
+        }
 
         if (profileImage != null && !profileImage.isEmpty()) {
             FileValidator.validateImage(profileImage);


### PR DESCRIPTION
# issue
#38 

# 변경점
- UserProfileUpdateRequest에 Schema(requiredMode = Schema.RequiredMode.NOT_REQUIRED) 어노테이션 추가, setName추가 (ModelAttribute 시 이미지 없이 name값만 변경 요청하면 name이 null이 되는 이슈 해결을 위해 추가)
- ModelAttribute 어노테이션으로 변경