### PR TITLE
[#49]Fix: Task 상태별 보드 조회 api에서 N+1 발생

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepository.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepository.java
@@ -1,9 +1,9 @@
 package com.twohundredone.taskonserver.task.repository;
 
-import com.twohundredone.taskonserver.task.entity.Task;
+import com.twohundredone.taskonserver.task.dto.TaskBoardItemDto;
 import com.twohundredone.taskonserver.task.enums.TaskPriority;
 import java.util.List;
 
 public interface TaskQueryRepository {
-    List<Task> findTasksWithFilters(Long projectId, String title, TaskPriority priority, Long userId);
+    List<TaskBoardItemDto> findBoardItemsWithFilters(Long projectId, String title, TaskPriority priority, Long userId);
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepositoryImpl.java
@@ -1,13 +1,21 @@
 package com.twohundredone.taskonserver.task.repository;
 
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.twohundredone.taskonserver.task.dto.TaskBoardItemDto;
+import com.twohundredone.taskonserver.task.dto.TaskBoardItemDto.TaskBoardItemDtoBuilder;
 import com.twohundredone.taskonserver.task.entity.QTask;
 import com.twohundredone.taskonserver.task.entity.QTaskParticipant;
 import com.twohundredone.taskonserver.task.entity.Task;
+import com.twohundredone.taskonserver.task.entity.TaskParticipant;
 import com.twohundredone.taskonserver.task.enums.TaskPriority;
 import com.twohundredone.taskonserver.user.entity.QUser;
+import com.twohundredone.taskonserver.user.entity.User;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -21,19 +29,17 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
     QUser user = QUser.user;
 
     @Override
-    public List<Task> findTasksWithFilters(
+    public List<TaskBoardItemDto> findBoardItemsWithFilters(
             Long projectId,
             String title,
             TaskPriority priority,
             Long userId
     ) {
 
-        return queryFactory
-                .select(task)
-                .distinct()
+        List<Tuple> rows = queryFactory
+                .select(task, taskParticipant, user)
                 .from(task)
-                .leftJoin(taskParticipant)
-                .on(taskParticipant.task.eq(task))
+                .leftJoin(taskParticipant).on(taskParticipant.task.eq(task))
                 .leftJoin(taskParticipant.user, user)
                 .where(
                         task.project.projectId.eq(projectId),
@@ -43,7 +49,57 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
                 )
                 .orderBy(task.createdAt.desc())
                 .fetch();
+
+        return convertToBoardItems(rows);
     }
+
+    private List<TaskBoardItemDto> convertToBoardItems(List<Tuple> rows) {
+
+        Map<Long, TaskBoardItemDto.TaskBoardItemDtoBuilder> grouped = new LinkedHashMap<>();
+        Map<Long, List<String>> participantImages = new LinkedHashMap<>();
+
+        for (Tuple row : rows) {
+            Task t = row.get(task);
+            TaskParticipant tp = row.get(taskParticipant);
+            User u = row.get(user);
+
+            grouped.putIfAbsent(
+                    t.getTaskId(),
+                    TaskBoardItemDto.builder()
+                            .taskId(t.getTaskId())
+                            .title(t.getTaskTitle())
+                            .status(t.getStatus())
+                            .priority(t.getPriority())
+                            .assigneeProfileImageUrl(null)
+                            .participantProfileImageUrls(new ArrayList<>())
+                            .commentCount(0)
+            );
+
+            participantImages.putIfAbsent(t.getTaskId(), new ArrayList<>());
+
+            if (tp != null && u != null) {
+                if (tp.getTaskRole().isAssignee()) {
+                    grouped.get(t.getTaskId())
+                            .assigneeProfileImageUrl(u.getProfileImageUrl());
+                } else {
+                    participantImages.get(t.getTaskId())
+                            .add(u.getProfileImageUrl());
+                }
+            }
+        }
+
+        // 최종 build
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    Long taskId = entry.getKey();
+                    TaskBoardItemDtoBuilder builder = entry.getValue();
+                    builder.participantProfileImageUrls(participantImages.get(taskId));
+                    return builder.build();
+                })
+                .toList();
+    }
+
+
 
     private BooleanExpression titleContains(String title) {
         return title != null ? task.taskTitle.containsIgnoreCase(title) : null;

--- a/src/main/java/com/twohundredone/taskonserver/task/service/TaskService.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/service/TaskService.java
@@ -368,14 +368,8 @@ public class TaskService {
                 .orElseThrow(() -> new CustomException(PROJECT_FORBIDDEN));
 
         // Task 목록 조회
-        List<Task> tasks = taskQueryRepository.findTasksWithFilters(
-                projectId, title, priority, userId
-        );
-
-        // Task → DTO 변환
-        List<TaskBoardItemDto> items = tasks.stream()
-                .map(this::convertToBoardItem)
-                .toList();
+        List<TaskBoardItemDto> items =
+                taskQueryRepository.findBoardItemsWithFilters(projectId, title, priority, userId);
 
         // 상태별로 분리
         return TaskBoardResponse.builder()
@@ -480,35 +474,6 @@ public class TaskService {
 
             taskParticipantRepository.save(taskParticipant);
         }
-    }
-
-    private TaskBoardItemDto convertToBoardItem(Task task) {
-
-        List<TaskParticipant> participants =
-                taskParticipantRepository.findAllByTask_TaskId(task.getTaskId());
-
-        TaskParticipant assignee = participants.stream()
-                .filter(TaskParticipant::isAssignee)
-                .findFirst()
-                .orElseThrow(() -> new CustomException(ASSIGNEE_NOT_FOUND));
-
-        List<String> participantImages =
-                participants.stream()
-                        .filter(TaskParticipant::isParticipant)
-                        .map(tp -> tp.getUser().getProfileImageUrl())
-                        .toList();
-
-        int commentCount = 0; // TODO: 댓글 기능 생기면 교체
-
-        return TaskBoardItemDto.builder()
-                .taskId(task.getTaskId())
-                .title(task.getTaskTitle())
-                .status(task.getStatus())       // 추가
-                .priority(task.getPriority())
-                .assigneeProfileImageUrl(assignee.getUser().getProfileImageUrl())
-                .participantProfileImageUrls(participantImages)
-                .commentCount(commentCount)
-                .build();
     }
 
     private List<TaskBoardItemDto> filterByStatus(


### PR DESCRIPTION
# issue
#49 

# 변경점
- QueryDSL로 한 번에 Task + Participant + User 조회하도록 코드를 수정하여 N+1해결