### PR TITLE
[#53]Fix: 프론트 배포환경에서 로그아웃 시 RefreshToken이 사라지지 않는 문제 해결

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/auth/controller/AuthController.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/controller/AuthController.java
@@ -96,9 +96,10 @@ public class    AuthController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request,
             HttpServletResponse response
     ) {
-        authService.logout(userDetails.getId(), response);
+        authService.logout(userDetails.getId(), request, response);
 
         return ResponseEntity.ok(
                 ApiResponse.success(SUCCESS_LOGOUT, null)

--- a/src/main/java/com/twohundredone/taskonserver/auth/service/AuthService.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/service/AuthService.java
@@ -134,20 +134,10 @@ public class AuthService {
     }
 
     // 로그아웃(RefreshToken 제거)
-    public void logout(Long userId, HttpServletResponse response)  {
-        // 1) Refresh Token 삭제 (Redis)
+    public void logout(Long userId, HttpServletRequest request, HttpServletResponse response) {
         refreshTokenService.delete(userId);
-
-        // 2) Refresh Token Cookie 삭제
-        ResponseCookie deleteCookie = ResponseCookie.from("refreshToken", "")
-                .httpOnly(true)
-                .secure(true)
-                .sameSite("None")
-                .path("/")
-                .maxAge(0)
-                .build();
-
-        response.addHeader("Set-Cookie", deleteCookie.toString());
+        CookieUtil.deleteRefreshTokenCookie(request, response);
         onlineStatusService.setOffline(userId);
     }
+
 }

--- a/src/main/java/com/twohundredone/taskonserver/auth/util/CookieUtil.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/util/CookieUtil.java
@@ -50,4 +50,26 @@ public class CookieUtil {
         }
         return null;
     }
+
+    public static void deleteRefreshTokenCookie(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        boolean isLocal = request.getServerName().contains("localhost");
+
+        ResponseCookie.ResponseCookieBuilder cookieBuilder =
+                ResponseCookie.from(REFRESH_TOKEN_COOKIE, "")
+                        .httpOnly(true)
+                        .path("/")
+                        .maxAge(0);
+
+        if (isLocal) {
+            cookieBuilder.secure(false).sameSite("Lax").domain(null);
+        } else {
+            cookieBuilder.secure(true).sameSite("None").domain(".taskon.co.kr");
+        }
+
+        response.addHeader("Set-Cookie", cookieBuilder.build().toString());
+    }
+
 }


### PR DESCRIPTION
# issue
#53 

# 변경점
- 로그아웃 로직에서 토큰 관련 처리를 CookieUtil로 이동
- RefreshToken삭제 시 도메인 추가