### PR TITLE
[#56]Docs:Swagger 인증 필요 API에 @SecurityRequirement 적용

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/chat/controller/ChatPersonalController.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/controller/ChatPersonalController.java
@@ -4,6 +4,7 @@ import com.twohundredone.taskonserver.auth.service.CustomUserDetails;
 import com.twohundredone.taskonserver.chat.dto.PersonalChatCreateRequest;
 import com.twohundredone.taskonserver.chat.dto.PersonalChatCreateResponse;
 import com.twohundredone.taskonserver.chat.service.ChatService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@SecurityRequirement(name = "Authorization")
 @RequestMapping("/api/chat/personal")
 public class ChatPersonalController {
 

--- a/src/main/java/com/twohundredone/taskonserver/chat/controller/ChatRestController.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/controller/ChatRestController.java
@@ -9,6 +9,7 @@ import com.twohundredone.taskonserver.chat.service.ChatService;
 import com.twohundredone.taskonserver.global.dto.ApiResponse;
 import com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
+
 public class ChatRestController {
 
     private final ChatService chatService;
@@ -28,6 +30,7 @@ public class ChatRestController {
             summary = "채팅방 리스트 조회",
             description = "로그인한 사용자가 속한 모든 채팅방 목록을 조회합니다."
     )
+    @SecurityRequirement(name = "Authorization")
     @GetMapping("/rooms")
     public ApiResponse<List<ChatRoomListResponse>> getMyRooms(
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -40,6 +43,7 @@ public class ChatRestController {
 
     // ✅ 채팅방 메시지 리스트 조회
     @Operation(summary = "채팅 메시지 리스트 조회", description = "특정 채팅방의 메시지 목록을 조회합니다.")
+    @SecurityRequirement(name = "Authorization")
     @GetMapping("/rooms/{chatRoomId}/messages")
     public ApiResponse<List<ChatMessageListResponse>> getMessages(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -57,6 +61,7 @@ public class ChatRestController {
             description = "특정 채팅방에 메시지를 전송합니다."
     )
     @PostMapping("/rooms/{chatRoomId}/messages")
+    @SecurityRequirement(name = "Authorization")
     public ResponseEntity<ApiResponse<ChatMessageSendResponse>> sendMessageRest(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long chatRoomId,

--- a/src/main/java/com/twohundredone/taskonserver/chat/controller/ChatStompController.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/controller/ChatStompController.java
@@ -3,6 +3,7 @@ package com.twohundredone.taskonserver.chat.controller;
 import com.twohundredone.taskonserver.chat.dto.ChatMessageRequest;
 import com.twohundredone.taskonserver.chat.dto.ChatMessageSendResponse;
 import com.twohundredone.taskonserver.chat.service.ChatService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -14,6 +15,7 @@ import java.security.Principal;
 
 @Controller
 @RequiredArgsConstructor
+@SecurityRequirement(name = "Authorization")
 public class ChatStompController {
 
     private final ChatService chatService;
@@ -21,6 +23,7 @@ public class ChatStompController {
 
     // SEND: /app/chat/rooms/{chatId}
     // SUB:  /topic/chat/rooms/{chatId}
+
     @MessageMapping("/chat/rooms/{chatId}")
     public void sendMessage(
             @DestinationVariable Long chatId,


### PR DESCRIPTION
# issue
#56

# 변경점
- Swagger 문서에서 JWT 인증이 필요한 채팅 관련 REST API에
  `@SecurityRequirement(name = "Authorization")` 추가
- 인증 필요 API에 Authorization 보안 요구사항 명시
