### PR TITLE
[#59]Fix: 댓글 관련 api에 불필요한 코드 제거 및 실 배포 시에 오류 발생할 가능성이 보이는 코드 수정

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/comment/controller/CommentController.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/controller/CommentController.java
@@ -1,5 +1,10 @@
 package com.twohundredone.taskonserver.comment.controller;
 
+import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.COMMENT_CREATE;
+import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.COMMENT_DELETE;
+import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.COMMENT_UPDATE;
+import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.GET_COMMENT_LIST;
+
 import com.twohundredone.taskonserver.auth.service.CustomUserDetails;
 import com.twohundredone.taskonserver.comment.dto.*;
 import com.twohundredone.taskonserver.comment.service.CommentService;
@@ -7,6 +12,7 @@ import com.twohundredone.taskonserver.global.dto.ApiResponse;
 import com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,43 +30,43 @@ public class CommentController {
     @Operation(summary = "댓글 생성", description = "댓글 생성 관련 API")
     @SecurityRequirement(name = "Authorization")
     @PostMapping
-    public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment
-            (@RequestBody CommentCreateRequest request,
+    public ResponseEntity<ApiResponse<CommentCreateResponse>> createComment(
+            @Valid @RequestBody CommentCreateRequest request,
             @PathVariable Long projectId, @PathVariable Long taskId,
             @AuthenticationPrincipal CustomUserDetails userDetails){
         CommentCreateResponse response = commentService.createComment(request, projectId, taskId, userDetails);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(ResponseStatusSuccess.COMMENT_CREATE, response));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(COMMENT_CREATE, response));
     }
 
     @Operation(summary = "댓글 조회", description = "댓글 조회 관련 API")
     @SecurityRequirement(name = "Authorization")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CommentListResponse>>> getComment
-            (@PathVariable Long projectId, @PathVariable Long taskId,
-             @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<ApiResponse<List<CommentListResponse>>> getComment(
+            @PathVariable Long projectId, @PathVariable Long taskId,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
         List<CommentListResponse> response = commentService.getComment(projectId, taskId, userDetails);
-        return ResponseEntity.ok(ApiResponse.success(ResponseStatusSuccess.GET_COMMENT_LIST, response));
+        return ResponseEntity.ok(ApiResponse.success(GET_COMMENT_LIST, response));
     }
 
     @Operation(summary = "댓글 수정", description = "댓글 수정 관련 API")
     @SecurityRequirement(name = "Authorization")
     @PatchMapping("{commentId}")
-    public ResponseEntity<ApiResponse<CommentUpdateResponse>> updateComment
-            (@PathVariable Long projectId, @PathVariable Long taskId, @PathVariable Long commentId,
-             @RequestBody CommentUpdateRequest request,
-             @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<ApiResponse<CommentUpdateResponse>> updateComment(
+            @PathVariable Long projectId, @PathVariable Long taskId, @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
         CommentUpdateResponse response = commentService.updateComment(projectId, taskId, commentId, request, userDetails);
-        return ResponseEntity.ok(ApiResponse.success(ResponseStatusSuccess.COMMENT_UPDATE, response));
+        return ResponseEntity.ok(ApiResponse.success(COMMENT_UPDATE, response));
     }
 
     @Operation(summary = "댓글 삭제", description = "댓글 삭제 관련 API")
     @SecurityRequirement(name = "Authorization")
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<ApiResponse<Void>> deleteComment
-            (@PathVariable Long projectId, @PathVariable Long taskId, @PathVariable Long commentId,
-             @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @PathVariable Long projectId, @PathVariable Long taskId, @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails){
         commentService.deleteComment(projectId, taskId, commentId, userDetails);
-        return ResponseEntity.ok(ApiResponse.success(ResponseStatusSuccess.COMMENT_DELETE, null));
+        return ResponseEntity.ok(ApiResponse.success(COMMENT_DELETE, null));
     }
 }
 

--- a/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentAuthorResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentAuthorResponse.java
@@ -1,0 +1,10 @@
+package com.twohundredone.taskonserver.comment.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CommentAuthorResponse(
+        Long userId,
+        String name,
+        String profileImageUrl
+) {}

--- a/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentCreateRequest.java
@@ -1,6 +1,10 @@
 package com.twohundredone.taskonserver.comment.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record CommentCreateRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 500, message = "댓글은 최대 500자까지 가능합니다.")
         String content
-) {
-}
+) {}

--- a/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentCreateResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentCreateResponse.java
@@ -1,26 +1,14 @@
 package com.twohundredone.taskonserver.comment.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
+import lombok.Builder;
 
-@Getter
 @Builder
-public class CommentCreateResponse {
-    private Long commentId;
-    private Long taskId;
-    private Author author;
-    private String content;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-
-    @Getter
-    @Builder
-    public static class Author {
-        private Long userId;
-        private String name;
-        private String profileImageUrl;
-    }
-}
+public record CommentCreateResponse(
+        Long commentId,
+        Long taskId,
+        CommentAuthorResponse author,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}

--- a/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentListResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentListResponse.java
@@ -1,26 +1,15 @@
 package com.twohundredone.taskonserver.comment.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 
-@Getter
 @Builder
-public class CommentListResponse {
-    private Long commentId;
-    private Author author;
-    private String content;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+public record CommentListResponse(
+        Long commentId,
+        CommentAuthorResponse author,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class Author{
-        private Long userId;
-        private String name;
-        private String profileImageUrl;
-    }
 }

--- a/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentUpdateRequest.java
@@ -1,6 +1,10 @@
 package com.twohundredone.taskonserver.comment.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record CommentUpdateRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        @Size(max = 500, message = "댓글은 최대 500자까지 가능합니다.")
         String content
-) {
-}
+) {}

--- a/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentUpdateResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/dto/CommentUpdateResponse.java
@@ -1,17 +1,14 @@
 package com.twohundredone.taskonserver.comment.dto;
 
 import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
 @Builder
-public class CommentUpdateResponse {
-    private Long commentId;
-    private String content;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+public record CommentUpdateResponse(
+        Long commentId,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
 }

--- a/src/main/java/com/twohundredone/taskonserver/comment/entity/Comment.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/entity/Comment.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Entity
 @Table(name = "comment")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -28,4 +27,8 @@ public class Comment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "task_id")
     private Task task;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/twohundredone/taskonserver/comment/repository/CommentRepository.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/repository/CommentRepository.java
@@ -7,5 +7,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByTask_TaskId(Long taskId);
+    List<Comment> findAllByTask_TaskIdOrderByCreatedAtAsc(Long taskId);
+    void deleteAllByTask_TaskId(Long taskId);
 }

--- a/src/main/java/com/twohundredone/taskonserver/global/enums/ResponseStatusError.java
+++ b/src/main/java/com/twohundredone/taskonserver/global/enums/ResponseStatusError.java
@@ -24,6 +24,7 @@ public enum ResponseStatusError {
     INVALID_PAST_DATE_CREATE(400, "시작일과 마감일은 오늘보다 이전일 수 없습니다."),
     INVALID_PAST_DATE_UPDATE(400, "마감일은 오늘보다 이전일 수 없습니다."),
     CHAT_BAD_REQUEST(400, "잘못된 요청입니다."),
+    COMMENT_TASK_MISMATCH(400, "해당 댓글은 이 업무에 속하지 않습니다."),
 
     //401 Unauthorized
     PASSWORD_INCORRECT(401, "비밀번호를 확인해주세요."),

--- a/src/main/java/com/twohundredone/taskonserver/global/enums/ResponseStatusSuccess.java
+++ b/src/main/java/com/twohundredone/taskonserver/global/enums/ResponseStatusSuccess.java
@@ -41,7 +41,7 @@ public enum ResponseStatusSuccess {
     PROJECT_CREATE(201, "프로젝트 생성을 완료했습니다."),
     ADD_PROJECT_MEMBER_SUCCESS(201, "프로젝트에 팀원을 추가하였습니다."),
     TASK_CREATE(201, "업무 생성을 완료했습니다."),
-    COMMENT_CREATE(201, "댓글 생성을 완료했습니다.");
+    COMMENT_CREATE(201, "댓글 생성을 완료했습니다."),
     CHAT_MESSAGE_SENT(201,"채팅 메시지를 전송했습니다." );
 
 

--- a/src/main/java/com/twohundredone/taskonserver/task/repository/TaskRepository.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/repository/TaskRepository.java
@@ -1,8 +1,10 @@
 package com.twohundredone.taskonserver.task.repository;
 
 import com.twohundredone.taskonserver.task.entity.Task;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TaskRepository extends JpaRepository<Task, Long> {
-
+    List<Task> findAllByProject_ProjectId(Long projectId);
+    void deleteAllByProject_ProjectId(Long projectId);
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/service/TaskService.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/service/TaskService.java
@@ -12,6 +12,7 @@ import static com.twohundredone.taskonserver.global.enums.ResponseStatusError.TA
 import static com.twohundredone.taskonserver.global.enums.ResponseStatusError.TASK_PROJECT_MISMATCH;
 import static com.twohundredone.taskonserver.global.enums.ResponseStatusError.USER_NOT_FOUND;
 
+import com.twohundredone.taskonserver.comment.repository.CommentRepository;
 import com.twohundredone.taskonserver.global.exception.CustomException;
 import com.twohundredone.taskonserver.project.entity.Project;
 import com.twohundredone.taskonserver.project.repository.ProjectMemberRepository;
@@ -50,6 +51,7 @@ public class TaskService {
     private final TaskParticipantRepository taskParticipantRepository;
     private final UserRepository userRepository;
     private final TaskQueryRepository taskQueryRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional
     public TaskCreateResponse createTask(Long loginUserId, Long projectId, TaskCreateRequest request) {
@@ -346,6 +348,9 @@ public class TaskService {
         if (!assignee.getUser().getUserId().equals(loginUserId)) {
             throw new CustomException(FORBIDDEN);
         }
+
+        // 댓글 먼저 삭제
+        commentRepository.deleteAllByTask_TaskId(taskId);
 
         // TaskParticipant 먼저 삭제
         taskParticipantRepository.deleteAllByTask_TaskId(taskId);


### PR DESCRIPTION
# issue
#59 

# 변경점
- 실 배포 시에 오류가 발생할 가능성이 보이는 코드가 많이 보여 해당 부분을 수정
- 검증/권한 확인 로직이 중복되어 해당 부분을 메서드로 따로 분비
- 불필요한 Setter와 생성자 Annotation을 제거
- 복잡한 구조가 아닌 ResponseDto는 record로 모두 변경