### PR TITLE
[#65]Fix: 채팅방 리스트 조회 시 발생하는 오류 해결

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatUserRepository.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatUserRepository.java
@@ -1,6 +1,7 @@
 package com.twohundredone.taskonserver.chat.repository;
 
 import com.twohundredone.taskonserver.chat.entity.ChatUser;
+import java.util.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,6 +12,7 @@ public interface ChatUserRepository extends JpaRepository<ChatUser, Long> {
     Optional<ChatUser> findByChatRoom_ChatIdAndUserId(Long chatId, Long userId);
 
     List<ChatUser> findAllByChatRoom_ChatId(Long chatId);
+    List<ChatUser> findAllByChatRoom_ChatIdIn(Collection<Long> chatRoomIds);
 
     boolean existsByChatRoom_ChatIdAndUserId(Long chatId, Long userId);
 

--- a/src/main/java/com/twohundredone/taskonserver/chat/service/ChatDomainService.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/service/ChatDomainService.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public interface ChatDomainService {
     // Project
-    void onProjectCreated(Long projectId, Long leaderUserId);
+    void onProjectCreated(Long projectId, String projectName, Long leaderUserId);
 
     void onProjectMembersAdded(Long projectId, List<Long> userIds);
 
@@ -13,7 +13,7 @@ public interface ChatDomainService {
     void onProjectDeleted(Long projectId);
 
     // Task
-    void onTaskCreated(Long taskId, List<Long> participantUserIds);
+    void onTaskCreated(Long taskId, String taskTitle, List<Long> participantUserIds);
 
     void onTaskParticipantsChanged(Long taskId, List<Long> participantUserIds);
 

--- a/src/main/java/com/twohundredone/taskonserver/chat/service/ChatDomainServiceImpl.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/service/ChatDomainServiceImpl.java
@@ -29,12 +29,12 @@ public class ChatDomainServiceImpl implements ChatDomainService {
     /* ================= Project ================= */
 
     @Override
-    public void onProjectCreated(Long projectId, Long leaderUserId) {
+    public void onProjectCreated(Long projectId, String projectName, Long leaderUserId) {
         ChatRoom room = chatRoomRepository.save(
                 ChatRoom.builder()
                         .chatType(PROJECT_GROUP)
                         .projectId(projectId)
-                        .chatRoomName("PROJECT-" + projectId)
+                        .chatRoomName(projectName)
                         .build()
         );
 
@@ -79,7 +79,7 @@ public class ChatDomainServiceImpl implements ChatDomainService {
     /* ================= Task ================= */
 
     @Override
-    public void onTaskCreated(Long taskId, List<Long> participantUserIds) {
+    public void onTaskCreated(Long taskId, String taskTitle, List<Long> participantUserIds) {
         if (chatRoomRepository.existsByChatTypeAndTaskId(TASK_GROUP, taskId)) {
             ChatRoom room = chatRoomRepository
                     .findByChatTypeAndTaskId(TASK_GROUP, taskId)
@@ -93,7 +93,7 @@ public class ChatDomainServiceImpl implements ChatDomainService {
                 ChatRoom.builder()
                         .chatType(TASK_GROUP)
                         .taskId(taskId)
-                        .chatRoomName("TASK-" + taskId)
+                        .chatRoomName(taskTitle)
                         .build()
         );
 

--- a/src/main/java/com/twohundredone/taskonserver/project/service/ProjectService.java
+++ b/src/main/java/com/twohundredone/taskonserver/project/service/ProjectService.java
@@ -52,7 +52,7 @@ public class ProjectService {
         project.addLeader(creator);
 
         Project savedProject = projectRepository.save(project);
-        chatDomainService.onProjectCreated(savedProject.getProjectId(), creator.getUserId());
+        chatDomainService.onProjectCreated(savedProject.getProjectId(), savedProject.getProjectName(), creator.getUserId());
 
         return ProjectCreateResponse.builder()
                 .projectId(savedProject.getProjectId())

--- a/src/main/java/com/twohundredone/taskonserver/task/service/TaskService.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/service/TaskService.java
@@ -131,7 +131,7 @@ public class TaskService {
                         .map(tp -> tp.getUser().getUserId())
                         .toList();
 
-        chatDomainService.onTaskCreated(savedTask.getTaskId(), chatParticipantIds);
+        chatDomainService.onTaskCreated(savedTask.getTaskId(), savedTask.getTaskTitle(), chatParticipantIds);
 
         List<Long> responseParticipantIds = participantIds.stream()
                 .filter(id -> !id.equals(loginUserId))


### PR DESCRIPTION
# issue
#65 

# 변경점
- ChatRoomListResponse에 null로 출력되는 필드가 보여 해당 필드에 데이터 삽입 로직 추가
- 채팅방 이름은 project 채팅방이면 projectName으로, task 채팅방이면 taskTitle로 생성되도록 수정