### PR TITLE
[#68]Fix: 메세지 전송 후 자신이 보낸 채팅은 바로 read처리

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/chat/service/ChatService.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/service/ChatService.java
@@ -135,7 +135,7 @@ public class ChatService {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new CustomException(CHAT_ROOM_NOT_FOUND));
 
-        getOrCreateChatUser(chatRoomId, senderId);
+        ChatUser chatUser = getOrCreateChatUser(chatRoomId, senderId);
 
         ChatMessage saved = chatMessageRepository.save(
                 ChatMessage.builder()
@@ -144,6 +144,9 @@ public class ChatService {
                         .content(request.content())
                         .build()
         );
+
+        // 내가 보낸 메시지는 즉시 읽음 처리
+        chatUser.updateLastReadAt(saved.getCreatedAt());
 
         return ChatMessageSendResponse.builder()
                 .messageId(saved.getChatMessageId())


### PR DESCRIPTION
# issue
#68 

# 변경점
- 채팅 메세지 전송 api 서비스단에 메세지 전송 후 즉시 읽음 처리 되도록 수정
- 