### PR TITLE
[#67][#70]Fix: Response에 채팅방 정보 추가, 채팅방 리스트 조회 api response 수정

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/chat/config/StompWebsocketConfig.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/config/StompWebsocketConfig.java
@@ -28,8 +28,8 @@ public class StompWebsocketConfig implements WebSocketMessageBrokerConfigurer {
 
         // 브라우저용 (SockJS)
         registry.addEndpoint("/ws/chat")
-                .setAllowedOriginPatterns(allowedOrigins)
-//                .setAllowedOriginPatterns("*")
+//                .setAllowedOriginPatterns(allowedOrigins)
+                .setAllowedOriginPatterns("*")
                 .withSockJS();
 
         // 테스트 / Postman / 순수 WebSocket용
@@ -41,6 +41,7 @@ public class StompWebsocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
         registry.enableSimpleBroker("/topic", "/queue");
+        registry.setUserDestinationPrefix("/user");
         registry.setApplicationDestinationPrefixes("/app");
     }
 

--- a/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatMessageSendResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatMessageSendResponse.java
@@ -1,5 +1,6 @@
 package com.twohundredone.taskonserver.chat.dto;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -8,5 +9,6 @@ public record ChatMessageSendResponse(
         Long chatRoomId,
         Long senderId,
         String content,
-        String sentTime
+        String sentTime,
+        LocalDateTime createdAt
 ) {}

--- a/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatParticipantFlatDto.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatParticipantFlatDto.java
@@ -1,0 +1,8 @@
+package com.twohundredone.taskonserver.chat.dto;
+
+public record ChatParticipantFlatDto(
+        Long chatRoomId,
+        Long userId,
+        String name,
+        String profileImageUrl
+) {}

--- a/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatRoomListResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatRoomListResponse.java
@@ -1,6 +1,8 @@
 package com.twohundredone.taskonserver.chat.dto;
 
 
+import com.twohundredone.taskonserver.chat.enums.ChatType;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -9,13 +11,16 @@ import lombok.Builder;
 public record ChatRoomListResponse(
         Long chatRoomId,
         String roomName,
+        ChatType chatType,
         List<Participant> participants,
         String lastMessage,
         String lastMessageTime,
+        LocalDateTime lastMessageAt,
         int unreadCount
 ) {
     public record Participant(
             Long userId,
+            String name,
             String profileImageUrl
     ) {}
 }

--- a/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatRoomSummaryDto.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatRoomSummaryDto.java
@@ -1,11 +1,13 @@
 package com.twohundredone.taskonserver.chat.dto;
 
+import com.twohundredone.taskonserver.chat.enums.ChatType;
 import java.time.LocalDateTime;
 
 public record ChatRoomSummaryDto(
         Long chatRoomId,
         String roomName,
+        ChatType chatType,
         String lastMessage,
-        LocalDateTime lastMessageAt,
+        LocalDateTime lastMessageAt,  // 원본
         int unreadCount
 ) {}

--- a/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatRoomUpdateEvent.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatRoomUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.twohundredone.taskonserver.chat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChatRoomUpdateEvent(
+        Long chatRoomId,
+        String lastMessage,
+        String lastMessageTime
+) {
+
+}

--- a/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatSearchResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/dto/ChatSearchResponse.java
@@ -1,22 +1,51 @@
 package com.twohundredone.taskonserver.chat.dto;
 
+import com.twohundredone.taskonserver.chat.enums.ChatType;
+import java.time.LocalDateTime;
 import java.util.List;
+import lombok.Builder;
 
 public record ChatSearchResponse(
-        List<UserSummary> users,
-        List<TaskSummary> tasks
+        List<ChatRoomSearchItem> chatRooms
 ) {
 
-    public record UserSummary(
+    @Builder
+    public record ChatRoomSearchItem(
+            Long chatRoomId,
+            String roomName,
+            ChatType chatType,
+            Long relatedTaskId,
+            String lastMessage,
+            LocalDateTime lastMessageAt,
+            int unreadCount,
+            List<ChatParticipantDto> participants
+    ) {
+        // QueryDSL 전용 생성자
+        public ChatRoomSearchItem(
+                Long chatRoomId,
+                String roomName,
+                ChatType chatType,
+                Long relatedTaskId,
+                String lastMessage,
+                LocalDateTime lastMessageAt,
+                int unreadCount
+        ) {
+            this(
+                    chatRoomId,
+                    roomName,
+                    chatType,
+                    relatedTaskId,
+                    lastMessage,
+                    lastMessageAt,
+                    unreadCount,
+                    List.of()   // 기본값
+            );
+        }
+    }
+
+    public record ChatParticipantDto(
             Long userId,
             String name,
             String profileImageUrl
-    ) {}
-
-    public record TaskSummary(
-            Long taskId,
-            Long projectId,
-            String taskTitle,
-            String priority
     ) {}
 }

--- a/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatRoomQueryRepositoryImpl.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatRoomQueryRepositoryImpl.java
@@ -18,7 +18,6 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
 
     QChatRoom chatRoom = QChatRoom.chatRoom;
     QChatUser chatUser = QChatUser.chatUser;
-    QChatMessage chatMessage = QChatMessage.chatMessage;
 
     @Override
     public List<ChatRoomSummaryDto> findMyChatRoomSummaries(Long userId) {
@@ -28,11 +27,12 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
         return queryFactory
                 .select(Projections.constructor(
                         ChatRoomSummaryDto.class,
-                        chatRoom.chatId,
-                        chatRoom.chatRoomName,
-                        lastMessage.content,
-                        lastMessage.createdAt,
-                        unreadMessage.chatMessageId.count().intValue()
+                        chatRoom.chatId,            // chatRoomId
+                        chatRoom.chatRoomName,      // roomName
+                        chatRoom.chatType,          // chatType
+                        lastMessage.content,        // lastMessage
+                        lastMessage.createdAt,      // lastMessageAt (원본 시간)
+                        unreadMessage.chatMessageId.count().intValue() // unreadCount
                 ))
                 .from(chatRoom)
                 .join(chatUser).on(
@@ -57,11 +57,11 @@ public class ChatRoomQueryRepositoryImpl implements ChatRoomQueryRepository {
                 .groupBy(
                         chatRoom.chatId,
                         chatRoom.chatRoomName,
+                        chatRoom.chatType,
                         lastMessage.content,
                         lastMessage.createdAt
                 )
                 .orderBy(chatRoom.modifiedAt.desc())
                 .fetch();
-
     }
 }

--- a/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatSearchQueryRepository.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatSearchQueryRepository.java
@@ -1,17 +1,10 @@
 package com.twohundredone.taskonserver.chat.repository;
 
-import com.twohundredone.taskonserver.chat.dto.ChatSearchResponse;
-import com.twohundredone.taskonserver.chat.dto.ChatSearchResponse.TaskSummary;
+import com.twohundredone.taskonserver.chat.dto.ChatParticipantFlatDto;
+import com.twohundredone.taskonserver.chat.dto.ChatSearchResponse.ChatRoomSearchItem;
 import java.util.List;
 
 public interface ChatSearchQueryRepository {
-    List<ChatSearchResponse.UserSummary> searchUsers(
-            Long userId,
-            String keyword
-    );
-
-    List<TaskSummary> searchTasks(
-            Long userId,
-            String keyword
-    );
+    List<ChatRoomSearchItem> searchChatRooms(Long userId, String keyword);
+    List<ChatParticipantFlatDto> findParticipantsByChatRoomIds(List<Long> chatRoomIds);
 }

--- a/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatSearchQueryRepositoryImpl.java
+++ b/src/main/java/com/twohundredone/taskonserver/chat/repository/ChatSearchQueryRepositoryImpl.java
@@ -1,15 +1,17 @@
 package com.twohundredone.taskonserver.chat.repository;
 
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.twohundredone.taskonserver.chat.dto.ChatSearchResponse;
-import com.twohundredone.taskonserver.chat.dto.ChatSearchResponse.UserSummary;
-import com.twohundredone.taskonserver.project.entity.QProjectMember;
+import com.twohundredone.taskonserver.chat.dto.ChatParticipantFlatDto;
+import com.twohundredone.taskonserver.chat.dto.ChatSearchResponse.ChatRoomSearchItem;
+import com.twohundredone.taskonserver.chat.entity.QChatMessage;
+import com.twohundredone.taskonserver.chat.entity.QChatRoom;
+import com.twohundredone.taskonserver.chat.entity.QChatUser;
 import com.twohundredone.taskonserver.task.entity.QTask;
-import com.twohundredone.taskonserver.task.entity.QTaskParticipant;
 import com.twohundredone.taskonserver.user.entity.QUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,110 +25,104 @@ public class ChatSearchQueryRepositoryImpl implements ChatSearchQueryRepository 
 
     private static final int SEARCH_LIMIT = 10;
 
+    QChatRoom chatRoom = QChatRoom.chatRoom;
+    QChatUser chatUser = QChatUser.chatUser;
+    QChatUser otherChatUser = new QChatUser("otherChatUser");
+    QChatMessage chatMessage = QChatMessage.chatMessage;
+    QChatMessage lastMessage = new QChatMessage("lastMessage");
     QUser user = QUser.user;
     QTask task = QTask.task;
-    QProjectMember pm = QProjectMember.projectMember;
-    QTaskParticipant tp = QTaskParticipant.taskParticipant;
 
-    // 사용자 검색
+
+    // 채팅 검색
     @Override
-    public List<UserSummary> searchUsers(Long userId, String keyword) {
+    public List<ChatRoomSearchItem> searchChatRooms(Long userId, String keyword) {
+
+        return baseChatRoomQuery(userId)
+                .leftJoin(otherChatUser).on(otherChatUser.chatRoom.eq(chatRoom))
+                .leftJoin(user).on(user.userId.eq(otherChatUser.userId))
+                .leftJoin(task).on(task.taskId.eq(chatRoom.taskId))
+                .where(searchCondition(userId, keyword))
+                .distinct()
+                .orderBy(lastMessage.createdAt.desc().nullsLast())
+                .limit(SEARCH_LIMIT)
+                .fetch();
+    }
+
+    @Override
+    public List<ChatParticipantFlatDto> findParticipantsByChatRoomIds(
+            List<Long> chatRoomIds
+    ) {
         return queryFactory
                 .select(Projections.constructor(
-                        ChatSearchResponse.UserSummary.class,
+                        ChatParticipantFlatDto.class,
+                        chatUser.chatRoom.chatId,
                         user.userId,
                         user.name,
                         user.profileImageUrl
                 ))
-                .from(user)
-                .where(
-                        containsKeyword(user.name, keyword),
-                        user.userId.ne(userId),
-                        existsRelation(userId)
-                )
-                .limit(SEARCH_LIMIT)
+                .from(chatUser)
+                .join(user).on(user.userId.eq(chatUser.userId))
+                .where(chatUser.chatRoom.chatId.in(chatRoomIds))
                 .fetch();
     }
 
-    // 업무 검색
-    @Override
-    public List<ChatSearchResponse.TaskSummary> searchTasks(Long userId, String keyword) {
+
+    // 공통 베이스 쿼리
+    private JPAQuery<ChatRoomSearchItem> baseChatRoomQuery(Long userId) {
+
         return queryFactory
                 .select(Projections.constructor(
-                        ChatSearchResponse.TaskSummary.class,
-                        task.taskId,
-                        task.project.projectId,
-                        task.taskTitle,
-                        task.priority.stringValue()
+                        ChatRoomSearchItem.class,
+                        chatRoom.chatId,
+                        chatRoom.chatRoomName,
+                        chatRoom.chatType,
+                        chatRoom.taskId,
+                        lastMessage.content,
+                        lastMessage.createdAt,
+                        unreadCountSubQuery(userId)
                 ))
-                .from(task)
-                .where(
-                        containsKeyword(task.taskTitle, keyword),
-                        taskAccessibleBy(userId)
+                .from(chatRoom)
+                .join(chatUser).on(chatUser.chatRoom.eq(chatRoom))
+                .leftJoin(lastMessage).on(
+                        lastMessage.chatRoom.eq(chatRoom),
+                        lastMessage.createdAt.eq(
+                                JPAExpressions
+                                        .select(chatMessage.createdAt.max())
+                                        .from(chatMessage)
+                                        .where(chatMessage.chatRoom.eq(chatRoom))
+                        )
                 )
-                .limit(SEARCH_LIMIT)
-                .fetch();
+                .where(chatUser.userId.eq(userId));
     }
 
-    // 접근 권한 필터
-    private BooleanExpression taskAccessibleBy(Long userId) {
-        return JPAExpressions
-                .selectOne()
-                .from(tp)
-                .where(
-                        tp.task.eq(task),
-                        tp.user.userId.eq(userId)
-                )
-                .exists()
+    // 검색 조건
+
+    private BooleanExpression searchCondition(Long userId, String keyword) {
+        if (keyword == null || keyword.isBlank()) return null;
+
+        return user.name.containsIgnoreCase(keyword)
+                .and(otherChatUser.userId.ne(userId))
                 .or(
-                        JPAExpressions
-                                .selectOne()
-                                .from(pm)
-                                .where(
-                                        pm.project.eq(task.project),
-                                        pm.user.userId.eq(userId)
-                                )
-                                .exists()
+                        task.taskTitle.containsIgnoreCase(keyword)
                 );
     }
 
-    // 사용자 관계 필터
-    private BooleanExpression existsRelation(Long userId) {
+    // 안 읽은 메시지 수 (lastReadAt 기준)
+    private Expression<Integer> unreadCountSubQuery(Long userId) {
 
-        QProjectMember pmMe = new QProjectMember("pmMe");
-        QProjectMember pmTarget = new QProjectMember("pmTarget");
-
-        QTaskParticipant tpMe = new QTaskParticipant("tpMe");
-        QTaskParticipant tpTarget = new QTaskParticipant("tpTarget");
+        QChatUser me = new QChatUser("me");
 
         return JPAExpressions
-                .selectOne()
-                .from(pmMe)
-                .join(pmTarget)
-                .on(pmMe.project.eq(pmTarget.project))
-                .where(
-                        pmMe.user.userId.eq(userId),
-                        pmTarget.user.userId.eq(user.userId)
+                .select(chatMessage.count().intValue())
+                .from(chatMessage)
+                .join(me).on(
+                        me.chatRoom.eq(chatRoom),
+                        me.userId.eq(userId)
                 )
-                .exists()
-                .or(
-                        JPAExpressions
-                                .selectOne()
-                                .from(tpMe)
-                                .join(tpTarget)
-                                .on(tpMe.task.eq(tpTarget.task))
-                                .where(
-                                        tpMe.user.userId.eq(userId),
-                                        tpTarget.user.userId.eq(user.userId)
-                                )
-                                .exists()
+                .where(
+                        chatMessage.chatRoom.eq(chatRoom),
+                        chatMessage.createdAt.after(me.lastReadAt)
                 );
-    }
-
-    // 공통 키워드 필터
-    private BooleanExpression containsKeyword(StringPath path, String keyword) {
-        return (keyword == null || keyword.isBlank())
-                ? null
-                : path.containsIgnoreCase(keyword);
     }
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/controller/TaskUserSearchController.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/controller/TaskUserSearchController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TaskUserSearchController {
     private final TaskUserSearchService taskUserSearchService;
 
-    @Operation(summary = "업무 배정 사용자 검색", description = "업무 생성/수정 시 배정 가능한 프로젝트 멤버 검색 API")
+    @Operation(summary = "사용자 검색 - 업무 배정", description = "업무 생성/수정 시 배정 가능한 프로젝트 멤버 검색 API")
     @SecurityRequirement(name = "Authorization")
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<SliceResponse<TaskUserSearchResponse>>> search(

--- a/src/main/resources/static/stomp-test.html
+++ b/src/main/resources/static/stomp-test.html
@@ -38,6 +38,7 @@
 <button onclick="connect()">CONNECT</button>
 <button onclick="subscribeRoom()">SUBSCRIBE</button>
 <button onclick="subscribeError()">SUBSCRIBE ERROR</button>
+<button onclick="subscribeRoomList()">SUBSCRIBE ROOM LIST</button>
 
 <hr>
 
@@ -63,7 +64,13 @@
 
     stompClient.connect(
         { Authorization: "Bearer " + token },
-        () => log("✅ CONNECTED"),
+        () => {
+          log("✅ CONNECTED");
+
+          // 🔥 여기서 바로 구독
+          subscribeError();
+          subscribeRoomList();
+        },
         (err) => log("❌ CONNECT ERROR: " + err)
     );
   }
@@ -88,6 +95,17 @@
     );
 
     log("✅ SUBSCRIBED error queue");
+  }
+
+  function subscribeRoomList() {
+    stompClient.subscribe(
+        "/user/queue/chat/rooms",
+        (msg) => {
+          log("🟡 ROOM LIST UPDATE: " + msg.body);
+        }
+    );
+
+    log("✅ SUBSCRIBED room list updates");
   }
 
   function sendMessage() {


### PR DESCRIPTION
# issue
#67 #70 

# 변경점
- Response에 채팅방 정보 추가
- participants 에 name 값 , chatType response에 추가
- lastMessageAt을 따로 추가
- 개인채팅방 RoomName이 PERSONAL -> 상대방 이름으로 나오도록 수정