### PR TITLE
[#47][#75]Fix: 댓글 리스트 조회 시 검증 로직 변경, 회원탈퇴 시 Board 조회와 Task 상세 조회 수정

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/comment/service/CommentService.java
+++ b/src/main/java/com/twohundredone/taskonserver/comment/service/CommentService.java
@@ -89,7 +89,7 @@ public class CommentService {
             throw new CustomException(TASK_PROJECT_MISMATCH);
         }
 
-        validateTaskAccess(projectId, taskId, userId);
+        validateProjectAccess(projectId, userId);
 
         List<Comment> commentList =
                 commentRepository.findAllByTask_TaskIdOrderByCreatedAtAsc(taskId);
@@ -151,6 +151,14 @@ public class CommentService {
     }
 
     // 공통 검증 메서드
+
+    // 프로젝트 멤버 검증
+    private void validateProjectAccess(Long projectId, Long userId) {
+        projectMemberRepository.findByProject_ProjectIdAndUser_UserId(projectId, userId)
+                .orElseThrow(() -> new CustomException(PROJECT_FORBIDDEN));
+    }
+
+    // 프로젝트 + 태스크 접근 검증
     private TaskParticipant validateTaskAccess(
             Long projectId,
             Long taskId,

--- a/src/main/java/com/twohundredone/taskonserver/task/controller/TaskController.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/controller/TaskController.java
@@ -13,6 +13,7 @@ import com.twohundredone.taskonserver.task.dto.TaskBoardResponse;
 import com.twohundredone.taskonserver.task.dto.TaskCreateRequest;
 import com.twohundredone.taskonserver.task.dto.TaskCreateResponse;
 import com.twohundredone.taskonserver.task.dto.TaskDetailResponse;
+import com.twohundredone.taskonserver.task.dto.TaskDetailView;
 import com.twohundredone.taskonserver.task.dto.TaskStatusUpdateRequest;
 import com.twohundredone.taskonserver.task.dto.TaskStatusUpdateResponse;
 import com.twohundredone.taskonserver.task.dto.TaskUpdateRequest;
@@ -53,12 +54,12 @@ public class TaskController {
     @Operation(summary = "Task 상세 조회", description = "Task 상세 정보를 조회합니다.")
     @SecurityRequirement(name = "Authorization")
     @GetMapping("/{taskId}")
-    public ResponseEntity<ApiResponse<TaskDetailResponse>> getTaskDetail(
+    public ResponseEntity<ApiResponse<TaskDetailView>> getTaskDetail(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long projectId,
             @PathVariable Long taskId
     ) {
-        TaskDetailResponse response =
+        TaskDetailView response =
                 taskService.getTaskDetail(userDetails.getId(), projectId, taskId);
 
         return ResponseEntity.ok(
@@ -107,11 +108,12 @@ public class TaskController {
             @PathVariable Long projectId,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) TaskPriority priority,
-            @RequestParam(required = false) Long userId
+            @RequestParam(required = false) Long userId,
+            @RequestParam(defaultValue = "false") boolean includeArchived
     ) {
 
         TaskBoardResponse response = taskService.getTaskBoard(
-                userDetails.getId(), projectId, title, priority, userId
+                userDetails.getId(), projectId, title, priority, userId, includeArchived
         );
 
         return ResponseEntity.ok(

--- a/src/main/java/com/twohundredone/taskonserver/task/dto/ArchivedTaskResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/dto/ArchivedTaskResponse.java
@@ -1,0 +1,38 @@
+package com.twohundredone.taskonserver.task.dto;
+
+import com.twohundredone.taskonserver.task.entity.Task;
+import com.twohundredone.taskonserver.task.enums.TaskPriority;
+import com.twohundredone.taskonserver.task.enums.TaskStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record ArchivedTaskResponse(
+        Long taskId,
+        Long projectId,
+        String title,
+        TaskStatus status,
+        TaskPriority priority,
+        String description,
+        LocalDate startDate,
+        LocalDate dueDate,
+        LocalDateTime archivedAt,
+        String archivedReason
+) implements TaskDetailView {
+
+    public static ArchivedTaskResponse from(Task task, String archivedReason) {
+        return ArchivedTaskResponse.builder()
+                .taskId(task.getTaskId())
+                .projectId(task.getProject().getProjectId())
+                .title(task.getTaskTitle())
+                .status(task.getStatus())
+                .priority(task.getPriority())
+                .description(task.getDescription())
+                .startDate(task.getStartDate())
+                .dueDate(task.getDueDate())
+                .archivedAt(task.getModifiedAt()) // archive 시점
+                .archivedReason(archivedReason)
+                .build();
+    }
+}

--- a/src/main/java/com/twohundredone/taskonserver/task/dto/TaskBoardResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/dto/TaskBoardResponse.java
@@ -7,7 +7,8 @@ import lombok.Builder;
 public record TaskBoardResponse(
         List<TaskBoardItemDto> todo,
         List<TaskBoardItemDto> inProgress,
-        List<TaskBoardItemDto> completed
+        List<TaskBoardItemDto> completed,
+        List<TaskBoardItemDto> archived
 ) {
 
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/dto/TaskDetailResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/dto/TaskDetailResponse.java
@@ -22,7 +22,7 @@ public record TaskDetailResponse(
 
         LocalDateTime createdAt,
         LocalDateTime updatedAt
-) {
+) implements TaskDetailView {
     @Builder
     public record AssigneeDto(
             Long userId,

--- a/src/main/java/com/twohundredone/taskonserver/task/dto/TaskDetailView.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/dto/TaskDetailView.java
@@ -1,0 +1,5 @@
+package com.twohundredone.taskonserver.task.dto;
+
+public interface TaskDetailView {
+
+}

--- a/src/main/java/com/twohundredone/taskonserver/task/entity/Task.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/entity/Task.java
@@ -99,4 +99,8 @@ public class Task extends BaseEntity {
         this.startDate = startDate;
         this.dueDate = dueDate;
     }
+
+    public void archive() {
+        this.status = TaskStatus.ARCHIVED;
+    }
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/enums/TaskStatus.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/enums/TaskStatus.java
@@ -3,17 +3,6 @@ package com.twohundredone.taskonserver.task.enums;
 public enum TaskStatus {
     TODO,
     IN_PROGRESS,
-    COMPLETED;
-
-    public boolean isTodo() {
-        return this == TODO;
-    }
-
-    public boolean isInProgress() {
-        return this == IN_PROGRESS;
-    }
-
-    public boolean isCompleted() {
-        return this == COMPLETED;
-    }
+    COMPLETED,
+    ARCHIVED;
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepository.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepository.java
@@ -5,5 +5,5 @@ import com.twohundredone.taskonserver.task.enums.TaskPriority;
 import java.util.List;
 
 public interface TaskQueryRepository {
-    List<TaskBoardItemDto> findBoardItemsWithFilters(Long projectId, String title, TaskPriority priority, Long userId);
+    List<TaskBoardItemDto> findBoardItemsWithFilters(Long projectId, String title, TaskPriority priority, Long userId, boolean includeArchived);
 }

--- a/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepositoryImpl.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/repository/TaskQueryRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.twohundredone.taskonserver.task.entity.QTaskParticipant;
 import com.twohundredone.taskonserver.task.entity.Task;
 import com.twohundredone.taskonserver.task.entity.TaskParticipant;
 import com.twohundredone.taskonserver.task.enums.TaskPriority;
+import com.twohundredone.taskonserver.task.enums.TaskStatus;
 import com.twohundredone.taskonserver.user.entity.QUser;
 import com.twohundredone.taskonserver.user.entity.User;
 import java.util.ArrayList;
@@ -33,7 +34,8 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
             Long projectId,
             String title,
             TaskPriority priority,
-            Long userId
+            Long userId,
+            boolean includeArchived
     ) {
 
         List<Tuple> rows = queryFactory
@@ -45,7 +47,8 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
                         task.project.projectId.eq(projectId),
                         titleContains(title),
                         priorityEq(priority),
-                        userCondition(userId)
+                        userCondition(userId),
+                        notArchivedUnlessIncluded(includeArchived)
                 )
                 .orderBy(task.createdAt.desc())
                 .fetch();
@@ -114,5 +117,9 @@ public class TaskQueryRepositoryImpl implements TaskQueryRepository {
         return userId != null
                 ? taskParticipant.user.userId.eq(userId)
                 : null;
+    }
+
+    private BooleanExpression notArchivedUnlessIncluded(boolean includeArchived) {
+        return includeArchived ? null : task.status.ne(TaskStatus.ARCHIVED);
     }
 }


### PR DESCRIPTION
# issue
#47 #75 

# 변경점
- 댓글 리스트 조회 시 검증 로직 변경
  - 같은 Project, 같은 Task에서만 접근 가능 -> 같은 Project면 접근 가능
- 회원탈퇴 시 Board 조회와 Task 상세 조회 수정
  - 회원탈퇴 시 그 회원이 마지막 Assignee나 Participant라면 Status 를 ARCHIVED로 변경
  - Board 조회 시 ARCHIVED된 Task 조회 여부 선택하여 조회하도록 수정
  - Task 상세 조회 시 ARCHIVED된 Task ResponseDto와 정상 Task 상제 조회 ResponseDto 따로 분리