### PR TITLE
[#82]Fix: 배포된 환경에서 ws/chat/info에서 403이 발생하는 문제 해결

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/twohundredone/taskonserver/auth/jwt/JwtAuthenticationFilter.java
@@ -27,8 +27,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request,
             HttpServletResponse response,
-            FilterChain filterChain)
-            throws ServletException, IOException {
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+
+        if (uri.startsWith("/ws")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         String token = jwtProvider.resolveAccessToken(request);
 


### PR DESCRIPTION
# issue
#82 

# 변경점
- WebSocket / SockJS 요청은 JWT 인증 대상이 아니기 때문에 Jwt 필터가 /ws를 검사하지 않도록 JwtAuthenticationFilter 코드를 수정