### PR TITLE
[#89]Fix: 회원 탈퇴 시 RefreshToken이 삭제되지 않는 문제 발생

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/user/controller/UserWithdrawController.java
+++ b/src/main/java/com/twohundredone/taskonserver/user/controller/UserWithdrawController.java
@@ -8,6 +8,8 @@ import com.twohundredone.taskonserver.global.dto.ApiResponse;
 import com.twohundredone.taskonserver.user.service.UserWithdrawService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,9 +28,11 @@ public class UserWithdrawController {
     @SecurityRequirement(name = "Authorization")
     @DeleteMapping("/me")
     public ResponseEntity<ApiResponse<Void>> withdraw(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request,
+            HttpServletResponse response
     ) {
-        userWithdrawService.withdraw(userDetails.getId());
+        userWithdrawService.withdraw(userDetails.getId(), request, response);
         return ResponseEntity.ok(
                 ApiResponse.success(SUCCESS_DELETE_USER, null)
         );

--- a/src/main/java/com/twohundredone/taskonserver/user/service/UserWithdrawService.java
+++ b/src/main/java/com/twohundredone/taskonserver/user/service/UserWithdrawService.java
@@ -3,6 +3,8 @@ package com.twohundredone.taskonserver.user.service;
 import static com.twohundredone.taskonserver.global.enums.ResponseStatusError.USER_NOT_FOUND;
 import static com.twohundredone.taskonserver.project.enums.Role.LEADER;
 
+import com.twohundredone.taskonserver.auth.service.RefreshTokenService;
+import com.twohundredone.taskonserver.auth.util.CookieUtil;
 import com.twohundredone.taskonserver.chat.repository.ChatUserRepository;
 import com.twohundredone.taskonserver.comment.repository.CommentRepository;
 import com.twohundredone.taskonserver.global.exception.CustomException;
@@ -16,6 +18,8 @@ import com.twohundredone.taskonserver.task.repository.TaskParticipantQueryReposi
 import com.twohundredone.taskonserver.task.repository.TaskParticipantRepository;
 import com.twohundredone.taskonserver.user.entity.User;
 import com.twohundredone.taskonserver.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserWithdrawService {
     private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final OnlineStatusService onlineStatusService;
     private final ProjectMemberRepository projectMemberRepository;
     private final TaskParticipantRepository taskParticipantRepository;
     private final ChatUserRepository chatUserRepository;
@@ -34,7 +40,8 @@ public class UserWithdrawService {
     private final ProjectMemberQueryRepository projectMemberQueryRepository;
     private final TaskParticipantQueryRepository taskParticipantQueryRepository;
 
-    public void withdraw(Long userId) {
+    @Transactional
+    public void withdraw(Long userId, HttpServletRequest request, HttpServletResponse response) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
@@ -44,7 +51,11 @@ public class UserWithdrawService {
         chatUserRepository.deleteAllByUserId(userId);
         commentRepository.clearUserReference(userId);
 
+        refreshTokenService.delete(userId);
+        onlineStatusService.setOffline(userId);
+
         userRepository.delete(user); // 🔥 Hard Delete
+        CookieUtil.deleteRefreshTokenCookie(request, response);
     }
 
     private void handleProjectMembers(User user) {


### PR DESCRIPTION
# issue
#89 

# 변경점
- service단에 RefreshToken 삭제, offline 여부 삭제 로직을 추가