### PR TITLE
[#86]Fix: PageImpl -> PageResponse로 반환 / Docs: prod-yml에 ES 설정 추가

### DIFF
--- a/src/main/java/com/twohundredone/taskonserver/common/dto/PageResponse.java
+++ b/src/main/java/com/twohundredone/taskonserver/common/dto/PageResponse.java
@@ -1,0 +1,25 @@
+package com.twohundredone.taskonserver.common.dto;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}
+

--- a/src/main/java/com/twohundredone/taskonserver/task/controller/TaskController.java
+++ b/src/main/java/com/twohundredone/taskonserver/task/controller/TaskController.java
@@ -8,6 +8,7 @@ import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.
 import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.TASK_UPDATE;
 import static com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess.UPDATED_TASK_STATUS;
 
+import com.twohundredone.taskonserver.common.dto.PageResponse;
 import com.twohundredone.taskonserver.global.dto.ApiResponse;
 import com.twohundredone.taskonserver.global.enums.ResponseStatusSuccess;
 import com.twohundredone.taskonserver.task.dto.TaskBoardItemDto;
@@ -147,7 +148,7 @@ public class TaskController {
     @Operation(summary = "Task 검색", description = "프로젝트 내 Task 검색/필터/페이징")
     @SecurityRequirement(name = "Authorization")
     @GetMapping("/search")
-    public ResponseEntity<ApiResponse<Page<TaskBoardItemDto>>> searchTasks(
+    public ResponseEntity<ApiResponse<PageResponse<TaskBoardItemDto>>> searchTasks(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long projectId,
             @RequestParam(required = false) String keyword,
@@ -168,7 +169,13 @@ public class TaskController {
                 size
         );
 
-        return ResponseEntity.ok(ApiResponse.success(GET_TASK_SEARCH_SUCCESS, result));
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        GET_TASK_SEARCH_SUCCESS,
+                        PageResponse.from(result)
+                )
+        );
+
     }
 
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -10,6 +10,9 @@ spring:
       host: ${SPRING_DATA_REDIS_HOST:redis}
       port: ${SPRING_DATA_REDIS_PORT:6379}
 
+  elasticsearch:
+    uris: ${SPRING_ELASTICSEARCH_URIS:${ES_URIS:http://elasticsearch:9200}}
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
# issue
#86 

# 변경점
- task board search api에서 PageImpl을 그대로 response하고 있어 PageResponse로 반환하도록 수정
- 배포환경을 위한 prod-yml에 ES 설정을 추가